### PR TITLE
feat(time-attribute): allow configuration of time attribute

### DIFF
--- a/MassTransit.CloudEvents/Configurator.cs
+++ b/MassTransit.CloudEvents/Configurator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Mime;
 
 namespace MassTransit.CloudEvents
@@ -26,6 +27,12 @@ namespace MassTransit.CloudEvents
             _deserializer.AddType<T>(type);
             _serializer.AddType<T>(type);
             
+            return this;
+        }
+
+        public IConfigurator WithTimeAttributeValueOnSerialize(Func<DateTimeOffset?> getTime)
+        {
+            _serializer.ConfigureTimeAttribute(getTime);
             return this;
         }
     }

--- a/MassTransit.CloudEvents/Serializer.cs
+++ b/MassTransit.CloudEvents/Serializer.cs
@@ -17,10 +17,17 @@ namespace MassTransit.CloudEvents
                 Data = context.Message,
                 Source = context.SourceAddress ?? new Uri("cloudeventify:masstransit"),
                 Id = context.MessageId.ToString(),
-                Type = Type(context.Message.GetType())
+                Type = Type(context.Message.GetType()),
+                Time = GetTimeValue?.Invoke()
             };
 
             stream.Write(cloudEvent.ToMessage().Span);
+        }
+
+        private Func<DateTimeOffset?> GetTimeValue;
+        public void ConfigureTimeAttribute(Func<DateTimeOffset?> getTime)
+        {
+            GetTimeValue = getTime;
         }
 
         public ContentType ContentType


### PR DESCRIPTION
The Time attribute for a CloudEvent is currently not set. It would be nice to be able to configure what value to set here on serializing (eg DateTimeOffset.UtcNow/DateTimeOffset.Now). The proposed change adds that capability, without changing current behaviour,