### PR TITLE
feat(time): set SentTime from CloudEvent on deserialize

### DIFF
--- a/MassTransit.CloudEvents.Tests/DeserializerTests.cs
+++ b/MassTransit.CloudEvents.Tests/DeserializerTests.cs
@@ -158,6 +158,47 @@ namespace MassTransit.CloudEvents.Tests
                 .BeFalse();
         }
 
+        [Fact]
+        public void UseSentTimeFromCloudEventTime()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.Default)
+            {
+                Data = "hello",
+                Source = new Uri("https://google.nl"),
+                Id = Guid.NewGuid().ToString(),
+                Type = "my-custom-event",
+                Time = DateTimeOffset.Now
+            };
+
+            using var context = ReceiveContext(cloudEvent.ToMessage());
+
+            var serializer = new Deserializer().As<IMessageDeserializer>();
+            serializer.Deserialize(context)
+                .SentTime
+                .Should()
+                .Be(cloudEvent.Time.Value.DateTime);
+        }
+
+        [Fact]
+        public void CloudEventTimeMayBeNull()
+        {
+            var cloudEvent = new CloudEvent(CloudEventsSpecVersion.Default)
+            {
+                Data = "hello",
+                Source = new Uri("https://google.nl"),
+                Id = Guid.NewGuid().ToString(),
+                Type = "my-custom-event"
+            };
+
+            using var context = ReceiveContext(cloudEvent.ToMessage());
+
+            var serializer = new Deserializer().As<IMessageDeserializer>();
+            serializer.Deserialize(context)
+                .SentTime
+                .Should()
+                .BeNull();
+        }
+
         private interface IEvent
         {
             int Id { get; }

--- a/MassTransit.CloudEvents/Deserializer.cs
+++ b/MassTransit.CloudEvents/Deserializer.cs
@@ -76,7 +76,7 @@ namespace MassTransit.CloudEvents
             public override Uri DestinationAddress { get; }
             public override Uri ResponseAddress { get; }
             public override Uri FaultAddress { get; }
-            public override DateTime? SentTime { get; }
+            public override DateTime? SentTime => _cloudEvent.Time?.LocalDateTime;
             public override Headers Headers { get; }
             public override HostInfo Host { get; }
             public override IEnumerable<string> SupportedMessageTypes { get; }


### PR DESCRIPTION
The Time property from the CloudEvent should be accessible further on in the pipeline (after unwrapping). This change sets the value of Context.SentTime to CloudEvent.Time