### PR TITLE
Adding configurable  Source mapping for Rebus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ riderModule.iml
 *.user
 StrykerOutput/
 reports/
+.vs

--- a/CloudEventify/CloudEventify.csproj
+++ b/CloudEventify/CloudEventify.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CloudNative.CloudEvents" Version="2.2.0" />
-      <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.2.0" />
+      <PackageReference Include="CloudNative.CloudEvents" Version="2.4.0" />
+      <PackageReference Include="CloudNative.CloudEvents.SystemTextJson" Version="2.4.0" />
       <PackageReference Include="System.Text.Json" Version="6.0.2" />
     </ItemGroup>
 

--- a/CloudEventify/ITypesMap.cs
+++ b/CloudEventify/ITypesMap.cs
@@ -1,6 +1,14 @@
 namespace CloudEventify;
 
-public interface ITypesMap : IMap<Type, string>, IMap<string, Type>
+public interface ITypesMap : IMap<Type, ITypeMap>, IMap<string, Type>
 {
     ITypesMap Map<T>(string type);
+    ITypesMap WithFormatSubject<T>(Func<T, string> formatSubject);
+}
+
+public interface ITypeMap
+{
+    string TypeName { get; }
+    Func<object, string> FormatSubject { get; }
+    ITypeMap WithFormatSubject<T>(Func<T, string> formatSubject);
 }

--- a/CloudEventify/TypesMapper.cs
+++ b/CloudEventify/TypesMapper.cs
@@ -1,20 +1,42 @@
 namespace CloudEventify;
 
+public class TypeMap : ITypeMap
+{
+    public string TypeName { get; private set; }
+    public Func<object, string> FormatSubject { get; private set; } = (a) => default;
+
+    public TypeMap(string typeName)
+    {
+        TypeName = typeName;
+    }
+
+    public ITypeMap WithFormatSubject<T>(Func<T, string> formatSubject)
+    {
+        FormatSubject = new Func<object, string>(obj => formatSubject((T)obj));
+        return this;
+    }
+}
+
 public class TypesMapper : ITypesMap
 {
     private readonly Dictionary<string, Type> _from = new();
-    private readonly Dictionary<Type, string> _to = new();
+    private readonly Dictionary<Type, ITypeMap> _to = new();
 
-    public ITypesMap Map<T>(string type)
+    public ITypesMap Map<T>(string typeName)
     {
-        _from[type] = typeof(T);
-        _to[typeof(T)] = type;
-        
+        _from[typeName] = typeof(T);
+        _to[typeof(T)] = new TypeMap(typeName);
+        return this;
+    }
+
+    public ITypesMap WithFormatSubject<T>(Func<T, string> formatSubject)
+    {
+        _to[typeof(T)].WithFormatSubject(formatSubject);
         return this;
     }
 
     public Type this[string type] => _from[type];
-    public string this[Type type] => _to[type];
+    public ITypeMap this[Type type] => _to[type];
     public bool Has(Type type) => _to.ContainsKey(type);
     public bool Has(string type) => _from.ContainsKey(type);
 }

--- a/Dapr/CloudEventity.Dapr.IntegrationTests/CloudEventity.Dapr.IntegrationTests.csproj
+++ b/Dapr/CloudEventity.Dapr.IntegrationTests/CloudEventity.Dapr.IntegrationTests.csproj
@@ -14,9 +14,9 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
         <PackageReference Include="Wrapr" Version="1.0.16" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Dapr/CloudEventity.Dapr/Wrap.cs
+++ b/Dapr/CloudEventity.Dapr/Wrap.cs
@@ -17,6 +17,6 @@ internal class Wrap
             Source = new Uri("cloudeventify:dapr"),
             Data = message,
             Time = DateTimeOffset.Now,
-            Type = _mapper[message.GetType()]
+            Type = _mapper[message.GetType()].TypeName
         };
 }

--- a/DaprApp.IntegrationTests/DaprApp.IntegrationTests.csproj
+++ b/DaprApp.IntegrationTests/DaprApp.IntegrationTests.csproj
@@ -13,8 +13,8 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
         <PackageReference Include="Wrapr" Version="1.0.16" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/MassTransit/CloudEventify.MassTransit.IntegrationTests/CloudEventify.MassTransit.IntegrationTests.csproj
+++ b/MassTransit/CloudEventify.MassTransit.IntegrationTests/CloudEventify.MassTransit.IntegrationTests.csproj
@@ -15,8 +15,8 @@
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.2" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Wrapr" Version="1.0.16" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/MassTransit/CloudEventify.MassTransit.Tests/CloudEventify.MassTransit.Tests.csproj
+++ b/MassTransit/CloudEventify.MassTransit.Tests/CloudEventify.MassTransit.Tests.csproj
@@ -11,8 +11,8 @@
         <PackageReference Include="Hypothesist.MassTransit" Version="2.0.30" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="NSubstitute" Version="4.3.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/MassTransit/CloudEventify.MassTransit/Wrap.cs
+++ b/MassTransit/CloudEventify.MassTransit/Wrap.cs
@@ -18,6 +18,6 @@ public class Wrap
             Source = context.SourceAddress ?? new Uri("cloudeventify:masstransit"),
             Data = context.Message,
             Time = context.SentTime,
-            Type = _map[typeof(T)]
+            Type = _map[typeof(T)].TypeName
         };
 }

--- a/Rebus/CloudEventify.Rebus.IntegrationTests/CloudEventify.Rebus.IntegrationTests.csproj
+++ b/Rebus/CloudEventify.Rebus.IntegrationTests/CloudEventify.Rebus.IntegrationTests.csproj
@@ -15,10 +15,10 @@
         <PackageReference Include="MartinCostello.Logging.XUnit" Version="0.2.0" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="Rebus.Microsoft.Extensions.Logging" Version="2.0.0" />
-        <PackageReference Include="Rebus.RabbitMq" Version="7.3.4" />
+        <PackageReference Include="Rebus.RabbitMq" Version="7.4.2" />
         <PackageReference Include="Wrapr" Version="1.0.16" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Rebus/CloudEventify.Rebus/Builder.cs
+++ b/Rebus/CloudEventify.Rebus/Builder.cs
@@ -10,12 +10,20 @@ internal class Builder : ICloudEvents
         .Map<SubscribeRequest>("subscribe");
 
     private readonly JsonSerializerOptions _options = new();
+    private Uri _source = new("cloudeventify:rebus");
+
     public ISerializer New() => 
-        new Serializer(Formatter.New(_options), new Wrap(_mapper), new Unwrap(_mapper, _options));
+        new Serializer(Formatter.New(_options), new Wrap(_mapper, _source), new Unwrap(_mapper, _options));
 
     ICloudEvents IConfigure<ICloudEvents>.WithJsonOptions(Action<JsonSerializerOptions> options)
     {
         options(_options);
+        return this;
+    }
+
+    ICloudEvents ICloudEvents.WithSource(Uri source)
+    {
+        _source = source;
         return this;
     }
 

--- a/Rebus/CloudEventify.Rebus/CloudEventify.Rebus.csproj
+++ b/Rebus/CloudEventify.Rebus/CloudEventify.Rebus.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Rebus" Version="6.0.0" />
+      <PackageReference Include="Rebus" Version="6.6.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Rebus/CloudEventify.Rebus/ICloudEvents.cs
+++ b/Rebus/CloudEventify.Rebus/ICloudEvents.cs
@@ -2,4 +2,10 @@ namespace CloudEventify.Rebus;
 
 public interface ICloudEvents : IConfigure<ICloudEvents>
 {
+    /// <summary>
+    /// Configure the Wrapper to use this Uri as the source on each outgoing message
+    /// </summary>
+    /// <param name="source">Source <see cref="Uri"/> used on each outgoing message</param>
+    /// <returns></returns>
+    ICloudEvents WithSource(Uri source);
 }

--- a/Rebus/CloudEventify.Rebus/Wrap.cs
+++ b/Rebus/CloudEventify.Rebus/Wrap.cs
@@ -19,9 +19,10 @@ public class Wrap
         new(CloudEventsSpecVersion.V1_0)
         {
             Id = message.GetMessageId(),
+            Subject = _mapper[message.Body.GetType()].FormatSubject(message.Body),
             Source = _source,
             Data = message.Body,
             Time = DateTimeOffset.Parse(message.Headers[Headers.SentTime]),
-            Type = _mapper[message.Body.GetType()]
+            Type = _mapper[message.Body.GetType()].TypeName
         };
 }

--- a/Rebus/CloudEventify.Rebus/Wrap.cs
+++ b/Rebus/CloudEventify.Rebus/Wrap.cs
@@ -7,15 +7,19 @@ namespace CloudEventify.Rebus;
 public class Wrap
 {
     private readonly ITypesMap _mapper;
+    private readonly Uri _source;
 
-    public Wrap(ITypesMap mapper) =>
+    public Wrap(ITypesMap mapper, Uri source)
+    {
         _mapper = mapper;
+        _source = source;
+    }
 
     public CloudEvent Envelope(Message message) =>
         new(CloudEventsSpecVersion.V1_0)
         {
             Id = message.GetMessageId(),
-            Source = new Uri("cloudeventify:rebus"),
+            Source = _source,
             Data = message.Body,
             Time = DateTimeOffset.Parse(message.Headers[Headers.SentTime]),
             Type = _mapper[message.Body.GetType()]

--- a/Rebus/CloudEventity.Rebus.Tests/CloudEventity.Rebus.Tests.csproj
+++ b/Rebus/CloudEventity.Rebus.Tests/CloudEventity.Rebus.Tests.csproj
@@ -11,10 +11,10 @@
         <PackageReference Include="FluentAssertions" Version="6.5.1" />
         <PackageReference Include="Hypothesist.Rebus" Version="2.0.30" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="Rebus" Version="6.0.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+        <PackageReference Include="Rebus" Version="6.6.5" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.extensibility.core" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/Rebus/CloudEventity.Rebus.Tests/SerializerTests.cs
+++ b/Rebus/CloudEventity.Rebus.Tests/SerializerTests.cs
@@ -30,7 +30,9 @@ public class SerializerTests
             .Subscriptions(s => s.StoreInMemory())
             .Routing(r => r.TypeBased().Map<A.UserLoggedIn>("user"))
             .Serialization(s => s.UseCloudEvents()
-                .WithTypes(types => types.Map<A.UserLoggedIn>("user.loggedIn")))
+                .WithTypes(types => types.Map<A.UserLoggedIn>("user.loggedIn").WithFormatSubject<A.UserLoggedIn>((obj) => { return $"user/{obj.Id}"; }))
+                .WithSource(new System.Uri("uri:MySourceApp"))
+                )
             .Start();
 
         await bus.Subscribe<A.UserLoggedIn>();

--- a/Rebus/CloudEventity.Rebus.Tests/WrapTests.cs
+++ b/Rebus/CloudEventity.Rebus.Tests/WrapTests.cs
@@ -1,0 +1,100 @@
+﻿using CloudEventify;
+using CloudEventify.Rebus;
+using Rebus.Messages;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace CloudEventity.Rebus.Tests
+{
+    public class WrapTests
+    {
+        [Fact]
+        public void EnvelopeWithConfiguredUri()
+        {
+            var sut = new Wrap(new TypesMapper().Map<string>("my-custom-event"), new Uri("test:uri"));
+            var res = sut.Envelope(new Message(
+                new Dictionary<string, string> { 
+                    { "rbs2-msg-id", Guid.NewGuid().ToString() },
+                    { "rbs2-senttime", DateTime.UtcNow.ToString() }
+                }, "somestringdata"));
+            Assert.NotNull(res);
+            Assert.Equal(new Uri("test:uri"), res.Source);
+        }
+
+        [Fact]
+        public void EnvelopeWithRequiredRebusHeaderMessageId()
+        {
+            var sut = new Wrap(new TypesMapper().Map<string>("my-custom-event"), new Uri("test:uri"));
+            var fact = Guid.NewGuid().ToString();
+            var res = sut.Envelope(new Message(
+                new Dictionary<string, string> {
+                    { "rbs2-msg-id", fact},
+                    { "rbs2-senttime", new DateTimeOffset(2007, 10, 31, 21, 0, 0, new TimeSpan(-8, 0, 0)).ToString() }
+                }, "somestringdata"));
+            Assert.NotNull(res.Time);
+            Assert.Equal(fact, res.Id);
+        }
+
+        [Fact]
+        public void EnvelopeWithRquiredRebusHeaderSenttime()
+        {
+            var sut = new Wrap(new TypesMapper().Map<string>("my-custom-event"), new Uri("test:uri"));
+            //Note you lose some precision due to serialization format
+            var fact = new DateTimeOffset(2007, 10, 31, 21, 0, 0, new TimeSpan(-8, 0, 0));
+            var res = sut.Envelope(new Message(
+                new Dictionary<string, string> {
+                    { "rbs2-msg-id", Guid.NewGuid().ToString() },
+                    { "rbs2-senttime", fact.ToString() }
+                }, "somestringdata"));
+            Assert.NotNull(res.Time);
+            Assert.Equal(fact, res.Time);
+        }
+
+        internal record SomeDataObject
+        {
+            public string? StringValue1 { get; init; }
+            public decimal DecimalValue1 { get; init; }
+            public DateTime DateTimeValue1 { get; init; }
+
+            public static SomeDataObject GetRandom()
+            {
+                return new SomeDataObject()
+                {
+                    StringValue1 = "",
+                    DecimalValue1 = 54.32M,
+                    DateTimeValue1 = DateTime.UtcNow
+                };
+            }
+        }
+
+        [Fact]
+        public void EnvelopeWithDataObjectFromBody()
+        {
+            var sut = new Wrap(new TypesMapper().Map<SomeDataObject>("myDataObjectTopic"), new Uri("test:uri"));
+            var fact = SomeDataObject.GetRandom();
+            var res = sut.Envelope(new Message(
+                new Dictionary<string, string> {
+                    { "rbs2-msg-id", Guid.NewGuid().ToString() },
+                    { "rbs2-senttime", new DateTimeOffset(2007, 10, 31, 21, 0, 0, new TimeSpan(-8, 0, 0)).ToString() }
+                }, fact));
+            Assert.NotNull(res.Data);
+            Assert.Equal(fact, res.Data);
+        }
+
+        [Fact]
+        public void EnvelopeWithMappedType()
+        {
+            var fact = new TypesMapper().Map<SomeDataObject>("someDataObject553").Map<string>("stringObject");
+            var sut = new Wrap(fact, new Uri("test:uri"));
+            var res = sut.Envelope(new Message(
+                new Dictionary<string, string> {
+                        { "rbs2-msg-id", Guid.NewGuid().ToString() },
+                        { "rbs2-senttime", new DateTimeOffset(2007, 10, 31, 21, 0, 0, new TimeSpan(-8, 0, 0)).ToString() }
+            }, SomeDataObject.GetRandom()));
+            Assert.NotNull(res.Type);
+            Assert.Equal(fact[res.Data!.GetType()], res.Type);
+        }
+
+}
+}


### PR DESCRIPTION
- Bumping a few of the packages
- Adding WithSource for Rebus (not needed for MassTransit, it is already mapped)
- Adding Wrapper / Mapper tests